### PR TITLE
Bump version of metals

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,7 +3,7 @@ image:
 vscode:
   extensions:
     - scala-lang.scala@0.3.9:kklqw+c/dNRmtTU8B5repw==
-    - scalameta.metals@1.9.0:KNju0fLBpNiyqH8qBfFeIQ==
+    - scalameta.metals@1.9.6:r4TvVGu3A2++o0cbEXt2Ig==
 ports:
   - port: 8212
     onOpen: ignore


### PR DESCRIPTION
This pr just bumps the version of the Metals extension up to ensure you're on the latest. We're working on having a `scalameta/metals-gitpod` example, but until then you can also just peak at https://github.com/tgodzik/metals-sample which I've updated today as well.