### PR TITLE
Update SBT to v1.6.2

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.6.2


### PR DESCRIPTION
The current version is pulling a version of log4j that we'd like to get rid of.